### PR TITLE
Remove deprecated Expo type definitions

### DIFF
--- a/bin/create-expo-app.js
+++ b/bin/create-expo-app.js
@@ -14,7 +14,6 @@ program
 
 const dependencies = ['react-native-kondo', 'react-navigation-stack'];
 const devDependencies = [
-  '@types/expo',
   '@types/jest',
   '@types/react-native',
   '@types/react-navigation',


### PR DESCRIPTION
Expo ships with their types now - the @types definitions are outdated and deprecated.